### PR TITLE
Error service

### DIFF
--- a/src/app/components/error-display/error-display.component.css
+++ b/src/app/components/error-display/error-display.component.css
@@ -1,3 +1,12 @@
 p {
     color: #FCA311;
 }
+
+.alert {
+    width: max-content;
+}
+
+#alert-container {
+    display: flex;
+    justify-content: center;
+}

--- a/src/app/components/error-display/error-display.component.html
+++ b/src/app/components/error-display/error-display.component.html
@@ -1,14 +1,16 @@
 <!-- PLAYING WITH BOOTSTRAP-->
-<div *ngIf = "getAlertWarning()" class="alert alert-warning alert-dismissible fade show" role="alert">
-    <strong>{{message}}</strong>
-    <button (click)="closeAlertWarning()" type="button" class="close" data-dismiss="alert" aria-label="Close">
-        <span aria-hidden="true">&times;</span>
-    </button>
-</div>
-
-<div *ngIf = "getAlertSuccess()" class="alert alert-success alert-dismissible fade show" role="alert">
-    <strong>{{message}}</strong>
-    <button (click)="closeAlertSuccess()" type="button" class="close" data-dismiss="alert" aria-label="Close">
-        <span aria-hidden="true">&times;</span>
-    </button>
+<div id="alert-container">
+    <div *ngIf = "getAlertWarning()" class="alert alert-warning alert-dismissible fade show" role="alert">
+        <strong>{{message}}</strong>
+        <button (click)="closeAlertWarning()" type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
+    
+    <div *ngIf = "getAlertSuccess()" class="alert alert-success alert-dismissible fade show" role="alert">
+        <strong>{{message}}</strong>
+        <button (click)="closeAlertSuccess()" type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+        </button>
+    </div>
 </div>

--- a/src/app/components/error-display/error-display.component.html
+++ b/src/app/components/error-display/error-display.component.html
@@ -1,14 +1,14 @@
 <!-- PLAYING WITH BOOTSTRAP-->
-<div *ngIf = "alertWarning" class="alert alert-warning alert-dismissible fade show" role="alert">
-    <strong>{{errorMessage}}</strong>
+<div *ngIf = "getAlertWarning()" class="alert alert-warning alert-dismissible fade show" role="alert">
+    <strong>{{message}}</strong>
     <button (click)="closeAlertWarning()" type="button" class="close" data-dismiss="alert" aria-label="Close">
-      <span aria-hidden="true">&times;</span>
+        <span aria-hidden="true">&times;</span>
     </button>
-  </div>
+</div>
 
-  <div *ngIf = "alertSuccess" class="alert alert-success alert-dismissible fade show" role="alert">
-    <strong>{{errorMessage}}</strong>
+<div *ngIf = "getAlertSuccess()" class="alert alert-success alert-dismissible fade show" role="alert">
+    <strong>{{message}}</strong>
     <button (click)="closeAlertSuccess()" type="button" class="close" data-dismiss="alert" aria-label="Close">
-      <span aria-hidden="true">&times;</span>
+        <span aria-hidden="true">&times;</span>
     </button>
-  </div>
+</div>

--- a/src/app/components/error-display/error-display.component.ts
+++ b/src/app/components/error-display/error-display.component.ts
@@ -12,6 +12,7 @@ export class ErrorDisplayComponent implements OnInit {
   constructor() { }
 
   ngOnInit(): void {
+    ErrorService.resetAlerts() // reset alerts due to static nature of service
   }
 
   getAlertWarning(): boolean {

--- a/src/app/components/error-display/error-display.component.ts
+++ b/src/app/components/error-display/error-display.component.ts
@@ -1,4 +1,5 @@
 import { Component, Input, OnInit } from '@angular/core';
+import { ErrorService } from 'src/app/services/error.service';
 
 @Component({
   selector: 'error-display',
@@ -6,20 +7,30 @@ import { Component, Input, OnInit } from '@angular/core';
   styleUrls: ['./error-display.component.css']
 })
 export class ErrorDisplayComponent implements OnInit {
-  @Input() alertWarning: boolean = false
-  @Input() alertSuccess: boolean = false
-  @Input() errorMessage: string = ""
+  @Input() message: string = ErrorService.getMessage()
 
   constructor() { }
 
   ngOnInit(): void {
   }
+
+  getAlertWarning(): boolean {
+    this.message = ErrorService.getMessage()
+    return ErrorService.getWarning()
+  }
+
+  getAlertSuccess(): boolean {
+    this.message = ErrorService.getMessage()
+    return ErrorService.getSuccess()
+  }
   
-    closeAlertWarning(){
-      this.alertWarning=false;
-    }
+  closeAlertWarning(){
+    ErrorService.setMessage("")
+    ErrorService.closeAlertWarning()
+  }
   
-    closeAlertSuccess(){
-      this.alertSuccess=false;
-    }
+  closeAlertSuccess(){
+    ErrorService.setMessage("")
+    ErrorService.closeAlertSuccess()
+  }
 }

--- a/src/app/components/register/register.component.html
+++ b/src/app/components/register/register.component.html
@@ -1,5 +1,5 @@
 <img src="../../../assets/images/pg-logo.svg" width="30%" height="30%" alt="Revature">
-<error-display [alertWarning]="hasError" [errorMessage]="errMsg"></error-display>
+<error-display></error-display>
 <form ngNativeValidate id="register-form" [formGroup]="registerForm" (ngSubmit)="onSubmit()">
     <div class="form-group">
       <label for="inputUserName">Username</label>

--- a/src/app/components/register/register.component.ts
+++ b/src/app/components/register/register.component.ts
@@ -10,10 +10,6 @@ import { ErrorService } from 'src/app/services/error.service';
   styleUrls: ['./register.component.css']
 })
 export class RegisterComponent implements OnInit {
-
-  hasError: boolean = false;
-  errMsg: string = "";
-
   registerForm = new FormGroup({
     uname: new FormControl(''),
     email: new FormControl(''),
@@ -30,7 +26,7 @@ export class RegisterComponent implements OnInit {
     this.authService.register(this.registerForm.get('uname')?.value, this.registerForm.get('email')?.value, this.registerForm.get('password')?.value).subscribe(
       () => console.log("New user registered"),
       (err) => {
-        this.hasError = ErrorService.displayWarning(true) // set the error state to true
+        ErrorService.displayWarning(true) // set the error state to true
         ErrorService.setMessage(err.error) // set the error message
       },
       () => this.router.navigate(['login'])

--- a/src/app/components/register/register.component.ts
+++ b/src/app/components/register/register.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { FormControl, FormGroup } from '@angular/forms';
 import { Router } from '@angular/router';
 import { AuthService } from 'src/app/services/auth.service';
+import { ErrorService } from 'src/app/services/error.service';
 
 @Component({
   selector: 'app-register',
@@ -23,15 +24,15 @@ export class RegisterComponent implements OnInit {
   constructor(private authService: AuthService, private router: Router) { }
 
   ngOnInit(): void {
+    ErrorService.resetAlerts() // reset alerts due to static nature of service
   }
   
   onSubmit(): void {
     this.authService.register(this.registerForm.get('uname')?.value, this.registerForm.get('email')?.value, this.registerForm.get('password')?.value).subscribe(
       () => console.log("New user registered"),
       (err) => {
-        console.log(err)
-        this.hasError = true
-        this.errMsg = err.error
+        this.hasError = ErrorService.displayWarning(true) // set the error state to true
+        ErrorService.setMessage(err.error) // set the error message
       },
       () => this.router.navigate(['login'])
     );

--- a/src/app/components/register/register.component.ts
+++ b/src/app/components/register/register.component.ts
@@ -24,7 +24,6 @@ export class RegisterComponent implements OnInit {
   constructor(private authService: AuthService, private router: Router) { }
 
   ngOnInit(): void {
-    ErrorService.resetAlerts() // reset alerts due to static nature of service
   }
   
   onSubmit(): void {

--- a/src/app/components/user-profile/user-profile.component.html
+++ b/src/app/components/user-profile/user-profile.component.html
@@ -1,20 +1,7 @@
 <app-navbar></app-navbar>
 
 <h1 id="header"> Account Information </h1>
-<!-- PLAYING WITH BOOTSTRAP-->
-<div *ngIf = "alertWarning" class="alert alert-warning alert-dismissible fade show" role="alert">
-    <strong>Update User Info Failed!</strong> Inputted email is already associated with an account.
-    <button (click)="closeAlertWarning()" type="button" class="close" data-dismiss="alert" aria-label="Close">
-      <span aria-hidden="true">&times;</span>
-    </button>
-  </div>
-
-  <div *ngIf = "alertSuccess" class="alert alert-success alert-dismissible fade show" role="alert">
-    <strong>Successfully Updated User Info!</strong> Account information should display user updates.
-    <button (click)="closeAlertSuccess()" type="button" class="close" data-dismiss="alert" aria-label="Close">
-      <span aria-hidden="true">&times;</span>
-    </button>
-  </div>
+<error-display></error-display>
 
 <p> User ID: {{user?.id}}</p>
 <p> First Name: {{user?.firstname}}</p>

--- a/src/app/components/user-profile/user-profile.component.ts
+++ b/src/app/components/user-profile/user-profile.component.ts
@@ -68,7 +68,6 @@ export class UserProfileComponent implements OnInit {
   constructor(private userService: UserService) { }
 
   ngOnInit(): void {
-    ErrorService.resetAlerts()
 
     console.log(this.userService);
 

--- a/src/app/components/user-profile/user-profile.component.ts
+++ b/src/app/components/user-profile/user-profile.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
 import { IUser } from 'src/app/components/Interfaces/IUser';
+import { ErrorService } from 'src/app/services/error.service';
 import { UserService } from 'src/app/services/user.service';
 import { User } from '../../models/user';
 
@@ -20,19 +21,6 @@ export class UserProfileComponent implements OnInit {
   userUsernameEditing: { username: string } = { username: "" };
   userEmailEditing: { email: string } = { email: "" };
   userPasswordEditing: { password: string } = { password: "" };
-
-  // ALERT FUNCTIONALITY
-  alertWarning:boolean=false;
-  alertSuccess:boolean=false;
-
-  closeAlertWarning(){
-    this.alertWarning=false;
-  }
-
-  closeAlertSuccess(){
-    this.alertSuccess=false;
-  }
-
 
   // Update Method
   onUpdate(): void {
@@ -55,17 +43,17 @@ export class UserProfileComponent implements OnInit {
       console.log("Checking UserService.update");
       this.userService.updateUser(user).subscribe(
         (response) => {
-          console.log(response);
+          ErrorService.setMessage("Success")
           this.user = response;
           this.toggleUpdateForm();
-          this.alertSuccess=true;
+          ErrorService.displaySuccess(true)
         },
 
         //error handling
         (error) => {
-          console.error(error);
+          ErrorService.setMessage("The email entered is already assocaited with another account.")
           console.log("There has been an error");
-          this.alertWarning=true;
+          ErrorService.displayWarning(true)
         }
 
       );
@@ -80,6 +68,7 @@ export class UserProfileComponent implements OnInit {
   constructor(private userService: UserService) { }
 
   ngOnInit(): void {
+    ErrorService.resetAlerts()
 
     console.log(this.userService);
 

--- a/src/app/services/error.service.spec.ts
+++ b/src/app/services/error.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ErrorService } from './error.service';
+
+describe('ErrorService', () => {
+  let service: ErrorService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ErrorService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/error.service.ts
+++ b/src/app/services/error.service.ts
@@ -1,0 +1,56 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class ErrorService {
+
+  static message: string = ""
+  static alertWarning: boolean = false
+  static alertSuccess: boolean = false
+
+  constructor() { }
+
+  public static getMessage(): string {
+    return this.message
+  }
+
+  public static getWarning(): boolean {
+    return this.alertWarning
+  }
+
+  public static getSuccess(): boolean {
+    return this.alertSuccess
+  }
+
+  public static setMessage(msg: string): string {
+    this.message = msg
+    return this.message
+  }
+
+  public static displayWarning(val: boolean): boolean{
+    this.alertWarning = val
+    this.alertSuccess = !val
+    return this.alertWarning
+  }
+
+  public static displaySuccess(val: boolean): boolean {
+    this.alertSuccess = val
+    this.alertWarning = !val
+    return this.alertSuccess
+  }
+
+  public static closeAlertWarning() {
+    this.alertWarning = false
+  }
+
+  public static closeAlertSuccess() {
+    this.alertSuccess = false
+  }
+
+  // call on init for any component
+  public static resetAlerts() {
+    this.alertSuccess = false
+    this.alertWarning = false
+  }
+}

--- a/src/app/services/error.service.ts
+++ b/src/app/services/error.service.ts
@@ -5,9 +5,9 @@ import { Injectable } from '@angular/core';
 })
 export class ErrorService {
 
-  static message: string = ""
-  static alertWarning: boolean = false
-  static alertSuccess: boolean = false
+  static message: string = "" // message for the alert
+  static alertWarning: boolean = false // state of warning box
+  static alertSuccess: boolean = false // state of success box
 
   constructor() { }
 
@@ -23,23 +23,27 @@ export class ErrorService {
     return this.alertSuccess
   }
 
+  // set the message within the alert box
   public static setMessage(msg: string): string {
     this.message = msg
     return this.message
   }
 
+  // will display warning/success based on boolean value - true: display, false: hide
+  // returns the value
   public static displayWarning(val: boolean): boolean{
     this.alertWarning = val
-    this.alertSuccess = !val
+    this.alertSuccess = false
     return this.alertWarning
   }
 
   public static displaySuccess(val: boolean): boolean {
     this.alertSuccess = val
-    this.alertWarning = !val
+    this.alertWarning = false
     return this.alertSuccess
   }
 
+  // closes the alert boxes
   public static closeAlertWarning() {
     this.alertWarning = false
   }
@@ -48,7 +52,7 @@ export class ErrorService {
     this.alertSuccess = false
   }
 
-  // call on init for any component
+  // resets alerts, called on the error component itself
   public static resetAlerts() {
     this.alertSuccess = false
     this.alertWarning = false

--- a/src/app/services/error.service.ts
+++ b/src/app/services/error.service.ts
@@ -30,17 +30,14 @@ export class ErrorService {
   }
 
   // will display warning/success based on boolean value - true: display, false: hide
-  // returns the value
-  public static displayWarning(val: boolean): boolean{
+  public static displayWarning(val: boolean): void{
     this.alertWarning = val
     this.alertSuccess = false
-    return this.alertWarning
   }
 
-  public static displaySuccess(val: boolean): boolean {
+  public static displaySuccess(val: boolean): void {
     this.alertSuccess = val
     this.alertWarning = false
-    return this.alertSuccess
   }
 
   // closes the alert boxes


### PR DESCRIPTION
- adding service to fix close alert bug
- allowing all manipulations through the ErrorService functions
- no configurations need to be done through the component tag itself

example usage within register.component.ts
```typescript
  onSubmit(): void {
    this.authService.register(this.registerForm.get('uname')?.value, this.registerForm.get('email')?.value, this.registerForm.get('password')?.value).subscribe(
      () => console.log("New user registered"),
      (err) => {
        ErrorService.displayWarning(true) // set the error state to true
        ErrorService.setMessage(err.error) // set the error message
      },
      () => this.router.navigate(['login'])
    );
  }
```
