### PR TITLE
Image lazy loading

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,6 +18,7 @@ import { SearchBarComponent } from './components/search/search-bar/search-bar.co
 
 import { SearchResultComponent } from './components/search/search-result/search-result.component';
 import { UserProfileComponent } from './components/user-profile/user-profile.component';
+import { LazyLoadImgDirective } from './directives/lazy-load-img.directive';
 
 
 @NgModule({
@@ -34,6 +35,7 @@ import { UserProfileComponent } from './components/user-profile/user-profile.com
     SearchBarComponent,
     SearchResultComponent,
     UserProfileComponent,
+    LazyLoadImgDirective,
   ],
   
   imports: [

--- a/src/app/components/product-card/product-card.component.html
+++ b/src/app/components/product-card/product-card.component.html
@@ -1,6 +1,7 @@
 <div class="card" style="width: 18rem">
-  <div class="card-body top">
+  <div class="card-body top" (lazyLoadImg)="showElement = true">
     <img
+      *ngIf="showElement"
       class="card-img-top"
       [src]="productInfo.image_url"
       alt="Card image cap"

--- a/src/app/components/product-card/product-card.component.ts
+++ b/src/app/components/product-card/product-card.component.ts
@@ -13,17 +13,15 @@ import { environment } from 'src/environments/environment';
 export class ProductCardComponent implements OnInit {
   @Input() productInfo!: Product;
 
-  constructor(
-    private cartservice: CartService,
-    private http: HttpClient,
-  ) {}
+  public showElement?: boolean;
 
-  ngOnInit(): void {
-  }
+  constructor(private cartservice: CartService, private http: HttpClient) {}
+
+  ngOnInit(): void {}
 
   async addToCart(product: Product): Promise<any> {
     let inCart = false;
-    let currentQuantity=0;
+    let currentQuantity = 0;
     let data = await this.http
       .get<Cartitem[]>(environment.baseUrl + '/api/cart', {
         headers: environment.headers,
@@ -37,9 +35,9 @@ export class ProductCardComponent implements OnInit {
       }
     });
     if (inCart) {
-        this.cartservice.updateQuantity(currentQuantity+1, product.id);      
+      this.cartservice.updateQuantity(currentQuantity + 1, product.id);
     } else {
-     this.cartservice.addToCart(product.id, 1);
+      this.cartservice.addToCart(product.id, 1);
     }
   }
 

--- a/src/app/directives/lazy-load-img.directive.spec.ts
+++ b/src/app/directives/lazy-load-img.directive.spec.ts
@@ -1,0 +1,8 @@
+import { LazyLoadImgDirective } from './lazy-load-img.directive';
+
+describe('LazyLoadImgDirective', () => {
+  it('should create an instance', () => {
+    const directive = new LazyLoadImgDirective();
+    expect(directive).toBeTruthy();
+  });
+});

--- a/src/app/directives/lazy-load-img.directive.ts
+++ b/src/app/directives/lazy-load-img.directive.ts
@@ -5,7 +5,7 @@ import { faImages } from '@fortawesome/free-solid-svg-icons';
   selector: '[lazyLoadImg]',
 })
 export class LazyLoadImgDirective {
-  /*   Basic lazy loading for faImages, using Intersection Observer API
+  /*   Basic lazy loading for images, using Intersection Observer API
        https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API 
   */
 
@@ -30,7 +30,18 @@ export class LazyLoadImgDirective {
   };
 
   public ngAfterViewInit() {
-    this.intersectionObserver = new IntersectionObserver(this.handleIntersect);
-    this.intersectionObserver.observe(this.element);
+    /// check if browser supports Intersection Observer API
+    if (
+      'IntersectionObserver' in window &&
+      'IntersectionObserverEntry' in window &&
+      'intersectionRatio' in window.IntersectionObserverEntry.prototype
+    ) {
+      this.intersectionObserver = new IntersectionObserver(
+        this.handleIntersect
+      );
+      this.intersectionObserver.observe(this.element);
+    } else {
+      this.lazyLoadImg.emit();
+    }
   }
 }

--- a/src/app/directives/lazy-load-img.directive.ts
+++ b/src/app/directives/lazy-load-img.directive.ts
@@ -1,0 +1,36 @@
+import { Directive, ElementRef, EventEmitter, Output } from '@angular/core';
+import { faImages } from '@fortawesome/free-solid-svg-icons';
+
+@Directive({
+  selector: '[lazyLoadImg]',
+})
+export class LazyLoadImgDirective {
+  /*   Basic lazy loading for faImages, using Intersection Observer API
+       https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API 
+  */
+
+  private intersectionObserver?: IntersectionObserver;
+  private element;
+
+  @Output() lazyLoadImg = new EventEmitter<any>();
+
+  constructor(elementRef: ElementRef) {
+    this.element = elementRef.nativeElement;
+  }
+
+  private handleIntersect = (entries: any): void => {
+    entries.forEach((entry: IntersectionObserverEntry) => {
+      if (entry.isIntersecting && entry.target === this.element) {
+        this.lazyLoadImg.emit();
+        //stop observing and disconnect
+        this.intersectionObserver?.unobserve(this.element);
+        this.intersectionObserver?.disconnect();
+      }
+    });
+  };
+
+  public ngAfterViewInit() {
+    this.intersectionObserver = new IntersectionObserver(this.handleIntersect);
+    this.intersectionObserver.observe(this.element);
+  }
+}


### PR DESCRIPTION
Intersection Observer API FTW

Tested with the narrow browser window, so that only a few products appear in the viewport at a time.

Load time (without lazy loading): 1.16s
Load time (lazy loading): 518ms

Just adding an Intersection observer to each image container, and waiting when that element intersects with the document viewport.